### PR TITLE
fix searchGif not using query parameter

### DIFF
--- a/lib/src/tenor.dart
+++ b/lib/src/tenor.dart
@@ -74,7 +74,7 @@ class Tenor {
     String contentFilter = ContentFilter.off,
     String mediaFilter = MediaFilter.minimal,
   }) async {
-    var url = 'https://api.tenor.com/v1/search?key=$apiKey';
+    var url = 'https://api.tenor.com/v1/search?key=$apiKey&q=$search';
     return await _privateRequestGif(
       url,
       limit: limit,


### PR DESCRIPTION
Hey, thanks for your work!

When I integrated your library I've noticed that "searchGif" method always returns the same results, so I investigated a little and found that in the implementation the "search" parameter was not used. I made a little fix and it seems to be working just fine for me now. 